### PR TITLE
Add CNAME for live site

### DIFF
--- a/CNAME
+++ b/CNAME
@@ -1,0 +1,1 @@
+iact.info


### PR DESCRIPTION
Merging this branch, which adds a CNAME file, should make iact.info live, by telling GitHub to serve the GH Pages build of `master` available as iact.info.